### PR TITLE
feat: Display champion skin count and modal

### DIFF
--- a/components/Inventory.js
+++ b/components/Inventory.js
@@ -38,7 +38,7 @@ const Inventory = ({ user }) => {
         <div className={styles.modalOverlay}>
           <div className={styles.modalContent}>
             <h2>{selectedChampionSkins.name} Skins</h2>
-            <button onClick={() => { setIsModalOpen(false); setSelectedChampionSkins(null); }} className={styles.closeButton}>Close</button>
+            <span onClick={() => { setIsModalOpen(false); setSelectedChampionSkins(null); }} className={styles.modalCloseIcon}>&times;</span>
             <div className={styles.skinsGrid}>
               {selectedChampionSkins.skins && selectedChampionSkins.skins.length > 0 ? (
                 selectedChampionSkins.skins.map((skin) => (

--- a/components/Inventory.js
+++ b/components/Inventory.js
@@ -1,17 +1,26 @@
 import styles from './Inventory.module.css';
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 const Inventory = ({ user }) => {
   const sortInventory = (inventory) => {
     return inventory?.sort((a, b) => b.level - a.level);
   }
   const inventory = useMemo(() => sortInventory(user?.inventory), [user]);
+
+  const [selectedChampionSkins, setSelectedChampionSkins] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleChampionClick = (champion) => {
+    setSelectedChampionSkins(champion);
+    setIsModalOpen(true);
+  };
+
   return (
     <div className={styles.inventoryContainer}>
       {
         inventory?.map((item, index) => {
           return (
-            <div className={styles.itemContainer} key={`${item.id}-${index}`}>
+            <div className={styles.itemContainer} key={`${item.id}-${index}`} onClick={() => handleChampionClick(item)}>
               <div>
                 <h3 className={styles.itemDesc}>{item.name}</h3>
                 <img
@@ -19,11 +28,36 @@ const Inventory = ({ user }) => {
                   src={`https://ddragon.leagueoflegends.com/cdn/img/champion/loading/${item.id}_0.jpg`}
                   alt="Problem"/>
                 <p className={styles.itemDesc}><strong>{item.level} {item.level >= 15 && '🤯' || item.level >= 10 && '💫' || item.level >= 5 && '🌟' || item.level >= 3 && '⭐'}</strong></p>
+                <p className={styles.itemDesc}>Skins: {item.skins?.length || 0}</p>
               </div>
             </div>
           );
         })
       }
+      {isModalOpen && selectedChampionSkins && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modalContent}>
+            <h2>{selectedChampionSkins.name} Skins</h2>
+            <button onClick={() => { setIsModalOpen(false); setSelectedChampionSkins(null); }} className={styles.closeButton}>Close</button>
+            <div className={styles.skinsGrid}>
+              {selectedChampionSkins.skins && selectedChampionSkins.skins.length > 0 ? (
+                selectedChampionSkins.skins.map((skin) => (
+                  <div key={skin.id} className={styles.skinItem}>
+                    <img
+                      src={`https://ddragon.leagueoflegends.com/cdn/img/champion/loading/${selectedChampionSkins.id}_${skin.num}.jpg`}
+                      alt={skin.name}
+                      className={styles.skinImage}
+                    />
+                    <p>{skin.name}</p>
+                  </div>
+                ))
+              ) : (
+                <p>No skins available for this champion.</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/components/Inventory.module.css
+++ b/components/Inventory.module.css
@@ -56,29 +56,15 @@
 }
 
 .modalContent {
-  background-color: #fff;
+  background-color: #2f2f33;
   padding: 20px;
   border-radius: 8px;
   width: 80%;
   max-width: 600px;
   max-height: 90vh;
   overflow-y: auto;
-  color: #333; /* Ensure text is visible on white background */
-}
-
-.closeButton {
-  background-color: #f44336;
-  color: white;
-  padding: 10px 15px;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  float: right;
-  margin-bottom: 10px;
-}
-
-.closeButton:hover {
-  background-color: #d32f2f;
+  color: #eaeaea; /* Ensure text is visible on white background */
+  position: relative; /* For positioning the close icon */
 }
 
 .skinsGrid {
@@ -90,7 +76,7 @@
 }
 
 .skinItem {
-  border: 1px solid #ddd;
+  border: 1px solid #555;
   border-radius: 4px;
   padding: 10px;
   text-align: center;
@@ -101,9 +87,25 @@
   height: auto;
   max-height: 200px; /* Adjust as needed */
   object-fit: cover; /* Or 'contain' depending on desired look */
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid #555;
   margin-bottom: 5px;
 }
 
 /* Ensure itemDesc for skin count is legible if not already handled */
 /* .itemDesc { already exists, assuming it's fine for skin count too } */
+
+.modalCloseIcon {
+  color: #9f9f9f; /* Light gray, consistent with other text */
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 24px; /* Make it larger */
+  font-weight: bold;
+  cursor: pointer;
+  padding: 5px; /* Add some padding for easier clicking */
+  line-height: 1; /* Ensure consistent height */
+}
+
+.modalCloseIcon:hover {
+  color: #eaeaea; /* Lighter gray on hover */
+}

--- a/components/Inventory.module.css
+++ b/components/Inventory.module.css
@@ -40,3 +40,70 @@
 .logo:hover {
   color: #58a7f6;
 }
+
+/* Modal styles */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modalContent {
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  width: 80%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+  color: #333; /* Ensure text is visible on white background */
+}
+
+.closeButton {
+  background-color: #f44336;
+  color: white;
+  padding: 10px 15px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  float: right;
+  margin-bottom: 10px;
+}
+
+.closeButton:hover {
+  background-color: #d32f2f;
+}
+
+.skinsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 15px;
+  margin-top: 20px; /* Add some space below the title/close button */
+  clear: both; /* Ensure it clears the floated close button */
+}
+
+.skinItem {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 10px;
+  text-align: center;
+}
+
+.skinImage {
+  width: 100%;
+  height: auto;
+  max-height: 200px; /* Adjust as needed */
+  object-fit: cover; /* Or 'contain' depending on desired look */
+  border-bottom: 1px solid #eee;
+  margin-bottom: 5px;
+}
+
+/* Ensure itemDesc for skin count is legible if not already handled */
+/* .itemDesc { already exists, assuming it's fine for skin count too } */


### PR DESCRIPTION
I've implemented functionality to enhance the champion inventory display:

- It now shows the number of skins available for each champion directly in the inventory list.
- I've added a modal that appears when you click a champion.
- The modal displays the champion's skins, including their names and images, fetched from the ddragon CDN.

This change involves modifications to `components/Inventory.js` for the logic and JSX, and `components/Inventory.module.css` for the necessary styling of the new UI elements.