### PR TITLE
feat: Implement champion skins display, modal, and total count

### DIFF
--- a/pages/inventory/index.js
+++ b/pages/inventory/index.js
@@ -8,6 +8,13 @@ export default function InventoryPage(props) {
     totalLevels += parseInt(item.level);
   });
 
+  let totalSkins = 0;
+  props.user.inventory.forEach((item) => {
+    if (item.skins && Array.isArray(item.skins)) { // Ensure skins is an array
+      totalSkins += item.skins.length;
+    }
+  });
+
   return (
     <div className={styles.container}>
       <Head>
@@ -19,7 +26,7 @@ export default function InventoryPage(props) {
         <span className={styles.number_champs}>
           {props.user.inventory.length}
         </span>{" "}
-        Champions
+        Champions and <span className={styles.number_skins}>{totalSkins}</span> Skins
       </h2>
       <h4 style={{ textAlign: "center" }}>Total levels: {totalLevels}</h4>
       <Inventory user={props.user} />


### PR DESCRIPTION
This commit introduces several enhancements to the champion inventory page:

1.  **Champion Skin Count**: Each champion in the inventory list now displays the number of skins available for that champion.
2.  **Skins Modal**:
    - Clicking on a champion opens a modal.
    - The modal lists all available skins for the selected champion, showing their names and images.
    - The modal uses a dark theme consistent with the application's overall design (#2f2f33 background).
    - The modal features an 'X' icon for closing, replacing the previous text button.
3.  **Total Skins Summary**:
    - The inventory page summary text now includes the total number of skins you possess across all champions.
    - The summary reads: "...you got a total of X Champions and Y Skins".

These changes were implemented by modifying:
- `components/Inventory.js`: For individual skin counts, modal logic, and modal JSX.
- `components/Inventory.module.css`: For styling the skin counts, modal, dark theme, and 'X' icon.
- `pages/inventory/index.js`: For calculating and displaying the total number of skins in the page summary.